### PR TITLE
Convert several parameters from double to float

### DIFF
--- a/Source/GuiEgTab.cpp
+++ b/Source/GuiEgTab.cpp
@@ -68,11 +68,11 @@ void GuiEgTab::resized()
 
 void GuiEgTab::sliderValueChanged (Slider* sliderThatWasMoved)
 {
-    double value = sliderThatWasMoved->getValue();
+    float value = (float)(sliderThatWasMoved->getValue());
     SynthParameters* pParams = pSound->pParams;
     if (sliderThatWasMoved == &attackSlider) pParams->ampEgAttackTimeSeconds = value;
     else if (sliderThatWasMoved == &decaySlider) pParams->ampEgDecayTimeSeconds = value;
-    else if (sliderThatWasMoved == &sustainSlider) pParams->ampEgSustainLevel = 0.01 * value;
+    else if (sliderThatWasMoved == &sustainSlider) pParams->ampEgSustainLevel = 0.01f * value;
     else if (sliderThatWasMoved == &releaseSlider) pParams->ampEgReleaseTimeSeconds = value;
     pSound->parameterChanged();
 }
@@ -82,6 +82,6 @@ void GuiEgTab::notify()
     SynthParameters* pParams = pSound->pParams;
     attackSlider.setValue(pParams->ampEgAttackTimeSeconds);
     decaySlider.setValue(pParams->ampEgDecayTimeSeconds);
-    sustainSlider.setValue(100.0 * pParams->ampEgSustainLevel);
+    sustainSlider.setValue(100.0f * pParams->ampEgSustainLevel);
     releaseSlider.setValue(pParams->ampEgReleaseTimeSeconds);
 }

--- a/Source/GuiMainTab.cpp
+++ b/Source/GuiMainTab.cpp
@@ -68,11 +68,11 @@ void GuiMainTab::resized()
 
 void GuiMainTab::sliderValueChanged (Slider* sliderThatWasMoved)
 {
-    double value = sliderThatWasMoved->getValue();
+    float value = (float)(sliderThatWasMoved->getValue());
     SynthParameters* pParams = pSound->pParams;
     if (sliderThatWasMoved == &masterLevelSlider)
     {
-        pParams->masterLevel = 0.1 * value;
+        pParams->masterLevel = 0.1f * value;
     }
     else if (sliderThatWasMoved == &pbUpSlider)
     {

--- a/Source/GuiOscTab.cpp
+++ b/Source/GuiOscTab.cpp
@@ -133,7 +133,7 @@ void GuiOscTab::comboBoxChanged (ComboBox* comboBoxThatHasChanged)
 
 void GuiOscTab::sliderValueChanged (Slider* sliderThatWasMoved)
 {
-    double value = sliderThatWasMoved->getValue();
+    float value = (float)(sliderThatWasMoved->getValue());
     SynthParameters* pParams = pSound->pParams;
     if (sliderThatWasMoved == &semiSlider1)
     {
@@ -153,7 +153,7 @@ void GuiOscTab::sliderValueChanged (Slider* sliderThatWasMoved)
     }
     else if (sliderThatWasMoved == &oscBlendSlider)
     {
-        pParams->oscBlend = 0.01 * value;
+        pParams->oscBlend = 0.01f * value;
     }
     pSound->parameterChanged();
 }

--- a/Source/SynthParameters.cpp
+++ b/Source/SynthParameters.cpp
@@ -3,20 +3,20 @@
 void SynthParameters::setDefaultValues()
 {
     programName = "Default";
-    masterLevel = 0.15;
-    oscBlend= 0.5;
+    masterLevel = 0.15f;
+    oscBlend= 0.5f;
     pitchBendUpSemitones = 2;
     pitchBendDownSemitones = 2;
     osc1Waveform.setToDefault();
     osc1PitchOffsetSemitones = 0;
-    osc1DetuneOffsetCents = -10.0;
+    osc1DetuneOffsetCents = -10.0f;
     osc2Waveform.setToDefault();
     osc2PitchOffsetSemitones = 0;
-    osc2DetuneOffsetCents = +10.0;
-    ampEgAttackTimeSeconds = 0.1;
-    ampEgDecayTimeSeconds = 0.1;
-    ampEgSustainLevel = 0.8;
-    ampEgReleaseTimeSeconds = 0.5;
+    osc2DetuneOffsetCents = +10.0f;
+    ampEgAttackTimeSeconds = 0.1f;
+    ampEgDecayTimeSeconds = 0.1f;
+    ampEgSustainLevel = 0.8f;
+    ampEgReleaseTimeSeconds = 0.5f;
 }
 
 XmlElement* SynthParameters::getXml()
@@ -50,21 +50,21 @@ void SynthParameters::putXml(XmlElement* xml)
 {
     programName = xml->getStringAttribute("name");
 
-    masterLevel = xml->getDoubleAttribute("masterLevel");
-    oscBlend = xml->getDoubleAttribute("oscBlend");
+    masterLevel = (float)(xml->getDoubleAttribute("masterLevel"));
+    oscBlend = (float)(xml->getDoubleAttribute("oscBlend"));
     pitchBendUpSemitones = xml->getIntAttribute("pitchBendUpSemitones");
     pitchBendDownSemitones = xml->getIntAttribute("pitchBendDownSemitones");
 
     osc1Waveform.setFromName(xml->getStringAttribute("osc1Waveform"));
     osc1PitchOffsetSemitones = xml->getIntAttribute("osc1PitchOffsetSemitones");
-    osc1DetuneOffsetCents = xml->getDoubleAttribute("osc1DetuneOffsetCents");
+    osc1DetuneOffsetCents = (float)(xml->getDoubleAttribute("osc1DetuneOffsetCents"));
 
     osc2Waveform.setFromName(xml->getStringAttribute("osc2Waveform"));
     osc2PitchOffsetSemitones = xml->getIntAttribute("osc2PitchOffsetSemitones");
-    osc2DetuneOffsetCents = xml->getDoubleAttribute("osc2DetuneOffsetCents");
+    osc2DetuneOffsetCents = (float)(xml->getDoubleAttribute("osc2DetuneOffsetCents"));
 
-    ampEgAttackTimeSeconds = xml->getDoubleAttribute("ampEgAttackTimeSeconds");
-    ampEgDecayTimeSeconds = xml->getDoubleAttribute("ampEgDecayTimeSeconds");
-    ampEgSustainLevel = xml->getDoubleAttribute("ampEgSustainLevel");
-    ampEgReleaseTimeSeconds = xml->getDoubleAttribute("ampEgReleaseTimeSeconds");
+    ampEgAttackTimeSeconds = (float)(xml->getDoubleAttribute("ampEgAttackTimeSeconds"));
+    ampEgDecayTimeSeconds = (float)(xml->getDoubleAttribute("ampEgDecayTimeSeconds"));
+    ampEgSustainLevel = (float)(xml->getDoubleAttribute("ampEgSustainLevel"));
+    ampEgReleaseTimeSeconds = (float)(xml->getDoubleAttribute("ampEgReleaseTimeSeconds"));
 }

--- a/Source/SynthParameters.h
+++ b/Source/SynthParameters.h
@@ -8,26 +8,26 @@ public:
     String programName;
 
     // main
-    double masterLevel;
-    double oscBlend;                        // [0.0, 1.0] relative osc1 level
+    float masterLevel;
+    float oscBlend;                        // [0.0, 1.0] relative osc1 level
     int pitchBendUpSemitones;
     int pitchBendDownSemitones;
     
     // osc 1
     SynthWaveform osc1Waveform;
     int osc1PitchOffsetSemitones;
-    double osc1DetuneOffsetCents;
+    float osc1DetuneOffsetCents;
     
     // osc 2
     SynthWaveform osc2Waveform;
     int osc2PitchOffsetSemitones;
-    double osc2DetuneOffsetCents;
+    float osc2DetuneOffsetCents;
     
     // amp EG
-    double ampEgAttackTimeSeconds;
-    double ampEgDecayTimeSeconds;
-    double ampEgSustainLevel;               // [0.0, 1.0]
-    double ampEgReleaseTimeSeconds;
+    float ampEgAttackTimeSeconds;
+    float ampEgDecayTimeSeconds;
+    float ampEgSustainLevel;               // [0.0, 1.0]
+    float ampEgReleaseTimeSeconds;
 
 public:
     // Set default values


### PR DESCRIPTION
I was going to try using class AudioProcessorValueTreeState for this plugin's parameters, but I'm not happy with the need to use getRawParameterValue() inside processBlock(), or the hoops one must jump through to set up parameter change listeners (see https://forum.juce.com/t/getrawparametervalue/22922/15), so I'm cutting this short and will try a simpler approach.